### PR TITLE
linux-raspberrypi-4.1: Add optional workaround patch for egl apps in containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Be able to workaround the issues with egl apps in containers using RPI_FIX_VCHIQ [Andrei]
+
 # v1.1.1 - 2016-03-16
 
 * Add support for Raspberrypi 3 [Theodor]

--- a/layers/meta-resin-raspberrypi/recipes-kernel/linux/linux-raspberrypi-4.1/fix-egl-apps-while-running-in-containers.patch
+++ b/layers/meta-resin-raspberrypi/recipes-kernel/linux/linux-raspberrypi-4.1/fix-egl-apps-while-running-in-containers.patch
@@ -1,0 +1,37 @@
+From 219d8ab2487510a31153baf50ff2819a8b92c11c Mon Sep 17 00:00:00 2001
+From: Andrei Gherzan <andrei@resin.io>
+Date: Thu, 21 Apr 2016 14:06:21 +0200
+Subject: [PATCH] vchiq_arm.c: When registering the calling process use
+ namespace pid
+
+Upstream-Status: Submitted [https://github.com/raspberrypi/linux/pull/1279]
+
+Signed-off-by: Andrei Gherzan <andrei@resin.io>
+---
+ drivers/misc/vc04_services/interface/vchiq_arm/vchiq_arm.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/misc/vc04_services/interface/vchiq_arm/vchiq_arm.c b/drivers/misc/vc04_services/interface/vchiq_arm/vchiq_arm.c
+index e11c0e0..399e485 100644
+--- a/drivers/misc/vc04_services/interface/vchiq_arm/vchiq_arm.c
++++ b/drivers/misc/vc04_services/interface/vchiq_arm/vchiq_arm.c
+@@ -48,6 +48,7 @@
+ #include <linux/of.h>
+ #include <linux/platform_device.h>
+ #include <soc/bcm2835/raspberrypi-firmware.h>
++#include <linux/sched.h>
+ 
+ #include "vchiq_core.h"
+ #include "vchiq_ioctl.h"
+@@ -1136,7 +1137,7 @@ vchiq_open(struct inode *inode, struct file *file)
+ 			return -ENOMEM;
+ 
+ 		instance->state = state;
+-		instance->pid = current->tgid;
++		instance->pid = task_pid_vnr(current);
+ 
+ 		ret = vchiq_debugfs_add_instance(instance);
+ 		if (ret != 0) {
+-- 
+2.1.4
+

--- a/layers/meta-resin-raspberrypi/recipes-kernel/linux/linux-raspberrypi_4.1.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-kernel/linux/linux-raspberrypi_4.1.bbappend
@@ -13,6 +13,13 @@ FT6X06_PATCHES = "\
     "
 SRC_URI += "${FT6X06_PATCHES}"
 
+# Workaround for egl apps in containers
+# This is WIP and should be activated only for specific usecases
+# https://github.com/raspberrypi/linux/issues/1382
+# https://github.com/raspberrypi/linux/pull/1279
+RPI_FIX_VCHIQ ?= "0"
+SRC_URI += "${@bb.utils.contains('RPI_FIX_VCHIQ', '1', ' file://fix-egl-apps-while-running-in-containers.patch', '', d)}"
+
 RESIN_CONFIGS_append = " ft6x06"
 RESIN_CONFIGS[ft6x06] = " \
    CONFIG_TOUCHSCREEN_FT6X06=m \


### PR DESCRIPTION
This patch is nit applied by default. If needed, activate it by setting:
RPI_FIX_VCHIQ = "1" in your local.conf.

@petrosagg @floion @telphan @lorenzo-stoakes 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/resin-os/resin-raspberrypi/13)
<!-- Reviewable:end -->
