### PR TITLE
Custom docker images in connectable builds on resin-raspberrypi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Custom docker images in connectable builds [Andrei]
 * Bump meta-resin to include connectable builds [Andrei]
 * Remove RPI_FIX_VCHIQ workaround as fix is included in our base images [Andrei]
 * Add support for optional supervisor image [Andrei]

--- a/layers/meta-resin-raspberrypi/recipes-containers/docker-disk/docker-resin-supervisor-disk.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-containers/docker-disk/docker-resin-supervisor-disk.bbappend
@@ -1,3 +1,3 @@
-TARGET_REPOSITORY_raspberrypi = "resin/rpi-supervisor"
-TARGET_REPOSITORY_raspberrypi2 = "resin/armv7hf-supervisor"
+SUPERVISOR_REPOSITORY_raspberrypi = "resin/rpi-supervisor"
+SUPERVISOR_REPOSITORY_raspberrypi2 = "resin/armv7hf-supervisor"
 LED_FILE_rpi = "/sys/class/leds/led0/brightness"


### PR DESCRIPTION
Connects to resin-os/meta-resin#133-supervisor-custom-image-tag
@telphan @floion