### PR TITLE
linux-raspberrypi: don't set kernel module compression here

### DIFF
--- a/layers/meta-resin-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -1,4 +1,4 @@
-inherit kernel-resin compress-kernel-modules
+inherit kernel-resin
 
 # Set console accordingly to build type
 DEBUG_CMDLINE = "dwc_otg.lpm_enable=0 console=tty1 console=serial0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait"


### PR DESCRIPTION
Module compression is now enabled globaly in "kernel-resin".

connect https://github.com/resin-os/meta-resin/pull/303