### PR TITLE
Update meta-resin to include supervisor v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Update meta-resin to include supervisor v2.5.0 [Pablo]
+
 # v1.16.0 - 2016-09-27
 
 * Update meta-resin to v1.16 [Florin]


### PR DESCRIPTION
Signed-off-by: Pablo Carranza Velez <pablo@resin.io>