### PR TITLE
do not default to RPi2 in the UI (RPi3 instead)

### DIFF
--- a/raspberrypi2.coffee
+++ b/raspberrypi2.coffee
@@ -8,7 +8,6 @@ module.exports =
 	name: 'Raspberry Pi 2'
 	arch: 'armv7hf'
 	state: 'released'
-	isDefault: true
 
 	instructions: commonImg.instructions
 	gettingStartedLink:


### PR DESCRIPTION
Currently the dashboard defaults to a Raspberry Pi 2 device when creating a new application. Should default to RPi3. This setting is already applied in `raspberrypi3.coffee` (that is currently more than one default is set), so this change just removes the value that overrides the desired default.

Connects to https://github.com/resin-io/hq/issues/439