### PR TITLE
resin-init-board: modprobe i2c-dev on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Load the i2c-dev kernel module at startup [Michal]
+
 # v2.0.0-beta13.rev3 - 2017-03-03
 
 * Deploy all available overlay dt files for Raspberry Pi [Michal]

--- a/layers/meta-resin-raspberrypi/recipes-support/resin-init/files/resin-init-board
+++ b/layers/meta-resin-raspberrypi/recipes-support/resin-init/files/resin-init-board
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+
+set -e
+
+modprobe i2c-dev
+
+exit 0

--- a/layers/meta-resin-raspberrypi/recipes-support/resin-init/resin-init-board.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-support/resin-init/resin-init-board.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend_rpi := "${THISDIR}/files:"
+
+RDEPENDS_${PN}_append = " kmod"


### PR DESCRIPTION
connect https://github.com/resin-os/resinos/issues/201