### PR TITLE
tests: Enable AutoHAT tests through Jenkins

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "layers/oe-meta-go"]
 	path = layers/oe-meta-go
 	url = https://github.com/mem/oe-meta-go.git
+[submodule "tests/autohat"]
+	path = tests/autohat
+	url = https://github.com/resin-io/autohat.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Enable AutoHAT tests through Jenkins [Praneeth]
+
 # v2.0.0-rc4.rev1 - 2017-03-20
 
 * Update meta-resin to v2.0.0-rc4 [Andrei]

--- a/tests/boardtest.sh
+++ b/tests/boardtest.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+set -e
+
+git submodule update --init autohat
+cd autohat
+APPLICATION_NAME=`echo $testNode | tr '[:upper:]' '[:lower:]'`
+
+cat <<EOM >start.sh
+#!/bin/sh
+cd /autohat
+robot --exitonerror --exitonfailure raspberrypi3.robot
+exit 0
+EOM
+chmod a+x start.sh
+
+docker build -t ${APPLICATION_NAME} .
+tar -xf ../../deploy/resin.img.tar.gz
+
+docker stop ${APPLICATION_NAME} || true
+docker rm ${APPLICATION_NAME} || true
+docker run -d -v `pwd`:/autohat --privileged \
+    --env INITSYSTEM=on \
+    --env RESINRC_RESIN_URL=${RESINRC_RESIN_URL} \
+    --env email=${RESIN_EMAIL} \
+    --env password=${RESIN_PASSWORD} \
+    --env device_type=${device_type} \
+    --env application_name=${APPLICATION_NAME} \
+    --env image=/autohat/resin.img \
+    --env rig_device_id=${rig_device_id} \
+    --env rig_sd_card=${rig_sd_card} \
+    --privileged \
+    --name=${APPLICATION_NAME} \
+    ${AUTOHAT_IMAGE} ${APPLICATION_NAME}
+    
+docker exec -t ${APPLICATION_NAME} /autohat/start.sh
+docker stop ${APPLICATION_NAME} || true
+docker rm ${APPLICATION_NAME} || true


### PR DESCRIPTION
This PR adds the AutoHAT repo for automated testing on resin-raspberrypi PRs. I have currently set this up for Raspberrypi3 with Jenkins. After this PR the control on whether or not to test lies with Jenkins where testing can be enabled/disabled. Below you can see a sample run with 2 checks - One AutoHAT and then Jenkins. We can make the AutoHAT tests as required in this repo after ensuring that the infrastructure is solid.

The variables used in the script are populated from the Jenkins Job and from Jenkins AutoHAT test rig slaves ( https://github.com/resin-io/autohat-resin-jenkins/blob/master/services/run_slave.sh )

The script is meant to be run from a Jenkins Job which populates the variables needed - https://jenkins.dev.resin.io/view/Yocto/job/AutoHAT-board-Tests/

Closes: https://github.com/resin-os/resinos/issues/240