### PR TITLE
Update build scripts to master on 1.X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Update resin-yocto-scripts to master [Will]
+
 # v1.26.0 - 2017-04-25
 
 * Update meta-resin to v1.26 [Andrei]


### PR DESCRIPTION
Update the build scripts on master to 1.X in order to fix meta-resin jenkins builds.