### PR TITLE
Add WiFi 5GHz connectivity warning for RPi 3 & Zero W

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Add WiFi 5GHz connectivity warning for RPi 3 & Zero W [Thodoris]
+
 # v2.0.8+rev1 - 2017-07-04
 
 * Update the meta-resin submodule to version v2.0.8 [Florin]

--- a/raspberrypi.coffee
+++ b/raspberrypi.coffee
@@ -9,6 +9,13 @@ module.exports =
 	arch: 'rpi'
 	state: 'released'
 
+	imageDownloadAlerts: [
+		{
+			type: 'warning'
+			message: 'The Raspberry Pi Zero W is not capable of connecting to 5GHz WiFi networks unless you use an external WiFi adapter that supports it.'
+		}
+	]
+
 	instructions: commonImg.instructions
 	gettingStartedLink:
 		windows: 'https://docs.resin.io/raspberrypi/nodejs/getting-started/#adding-your-first-device'

--- a/raspberrypi3-64.coffee
+++ b/raspberrypi3-64.coffee
@@ -9,6 +9,13 @@ module.exports =
 	arch: 'aarch64'
 	state: 'experimental'
 
+	imageDownloadAlerts: [
+		{
+			type: 'warning'
+			message: 'The Raspberry Pi 3 is not capable of connecting to 5GHz WiFi networks unless you use an external WiFi adapter that supports it.'
+		}
+	]
+
 	instructions: commonImg.instructions
 	gettingStartedLink:
 		windows: 'https://docs.resin.io/raspberrypi3/nodejs/getting-started/#adding-your-first-device'

--- a/raspberrypi3.coffee
+++ b/raspberrypi3.coffee
@@ -10,6 +10,13 @@ module.exports =
 	state: 'released'
 	isDefault: true
 
+	imageDownloadAlerts: [
+		{
+			type: 'warning'
+			message: 'The Raspberry Pi 3 is not capable of connecting to 5GHz WiFi networks unless you use an external WiFi adapter that supports it.'
+		}
+	]
+
 	instructions: commonImg.instructions
 	gettingStartedLink:
 		windows: 'https://docs.resin.io/raspberrypi3/nodejs/getting-started/#adding-your-first-device'


### PR DESCRIPTION
raspberrypi.coffee: add imageDownloadAlerts
raspberrypi3-64.coffee: add imageDownloadAlerts
raspberrypi3.coffee: add imageDownloadAlerts

Adds a warning on the download image modal of the dashboard  about the need of an external WiFi adapter in case the user intents to use the RPi on 5GHz WiFi networks.

See: https://github.com/resin-io/resin-ui/issues/1102
See: [arch call 2017-07-19](https://github.com/resin-io/hq/wiki/Architecture-Calls#19-jul-2017)

Signed-off-by: Thodoris Greasidis <thodoris@resin.io>