### PR TITLE
resin-yocto-scripts: Update to latest master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Update the resin-yocto-scripts submodule to HEAD of master [Will]
+
 # v2.3.0+rev1 - 2017-08-17
 
 * Update the meta-resin submodule to version v2.3.0 [Florin]


### PR DESCRIPTION
This includes a fix for building with specific supervisor tags.

Change-type: patch
Changelog-entry: Update resin-yocto-scripts to master
Signed-off-by: Will Newton <willn@resin.io>