### PR TITLE
Update build scripts to latest master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Update the resin-yocto-scripts again to fix Pyro build [Will]
 * Update the resin-yocto-scripts to fix Pyro build [Will]
 * Update the resin-yocto-scripts submodule to HEAD of master [Will]
 


### PR DESCRIPTION

Hopefully this should fix the Jenkins build with Pyro by pulling the latest yocto-build-env.