### PR TITLE
rpi: set always overcommit policy on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Enabled always overcommit VM mode [Yossi]
 * Add meta-rust submodule [Will]
 * Update resin-yocto-scripts to include deployment of docker images [Andrei]
 

--- a/layers/meta-resin-raspberrypi/recipes-core/enable-overcommit/enable-overcommit.bb
+++ b/layers/meta-resin-raspberrypi/recipes-core/enable-overcommit/enable-overcommit.bb
@@ -1,0 +1,10 @@
+DESCRIPTION = "Enable memory overcommit"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${RESIN_COREBASE}/COPYING.Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = "file://enable-overcommit.conf"
+
+do_install() {
+	mkdir -p ${D}${sysconfdir}/sysctl.d
+	install -m 0644 ${WORKDIR}/enable-overcommit.conf ${D}${sysconfdir}/sysctl.d
+}

--- a/layers/meta-resin-raspberrypi/recipes-core/enable-overcommit/files/enable-overcommit.conf
+++ b/layers/meta-resin-raspberrypi/recipes-core/enable-overcommit/files/enable-overcommit.conf
@@ -1,0 +1,1 @@
+vm.overcommit_memory=1

--- a/layers/meta-resin-raspberrypi/recipes-core/images/resin-image.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-core/images/resin-image.bbappend
@@ -36,3 +36,5 @@ python overlay_dtbs_handler () {
 
 addhandler overlay_dtbs_handler
 overlay_dtbs_handler[eventmask] = "bb.event.RecipePreFinalise"
+
+IMAGE_INSTALL_append_rpi = " enable-overcommit"


### PR DESCRIPTION
Golang allocate large region of virtual memory
in order to properly handle several go binaries
process this enables the always overcommit policy.

https://golang.org/doc/faq#Why_does_my_Go_process_use_so_much_virtual_memory

Signed-off-by: Yossi Eliaz <yossi@resin.io>