### PR TITLE
WIP initrdscripts: Add usbflasher script

### DIFF
--- a/layers/meta-resin-raspberrypi/recipes-core/images/resin-image-initramfs.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-core/images/resin-image-initramfs.bbappend
@@ -1,0 +1,6 @@
+
+PACKAGE_INSTALL += " \
+	initramfs-module-usbflasher \
+	kernel-module-dwc2 \
+	kernel-module-g-mass-storage \
+	"

--- a/layers/meta-resin-raspberrypi/recipes-core/initrdscripts/files/usbflasher
+++ b/layers/meta-resin-raspberrypi/recipes-core/initrdscripts/files/usbflasher
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+usbflasher_enabled() {
+	grep -q 'resinos.usbflasher' /proc/cmdline
+        if [ $? -eq 0 ]; then
+		echo "Raspberry Pi USB flasher mode enabled"
+		return 0
+	fi
+	return 1
+}
+
+usbflasher_run() {
+	hardware=$(grep ^Hardware /proc/cpuinfo | cut -f 2 -d :)
+	revision=$(grep ^Revision /proc/cpuinfo | cut -f 2 -d :)
+	modprobe g_mass_storage file=/dev/mmcblk0 iProduct="RPi${hardware}${revision}"
+	while true; do
+		sleep 60
+	done
+}

--- a/layers/meta-resin-raspberrypi/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -1,0 +1,17 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI_append = " \
+    file://usbflasher \
+    "
+
+do_install_append() {
+    install -m 0755 ${WORKDIR}/usbflasher ${D}/init.d/20-usbflasher
+}
+
+PACKAGES_append = " \
+    initramfs-module-usbflasher \
+    "
+
+SUMMARY_initramfs-module-usbflasher = "initramfs support for switching into USB flasher mode"
+RDEPENDS_initramfs-module-usbflasher = "${PN}-base"
+FILES_initramfs-module-usbflasher = "/init.d/20-usbflasher"


### PR DESCRIPTION
Add usbflasher script which checks for a kernel command line
argument "resinos.usbflasher". If that argument is present then
the g_mass_storage driver is loaded with the mmc device as the
backing storage and the boot is halted.

Signed-off-by: Will Newton <willn@resin.io>