### PR TITLE
linux-raspberrypi_%.bbappend: Fix pca955 GPIO expander kernel configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Fix typo in enabling support for PCA955 GPIO expander [Florin]
+
 # v2.7.4+rev1
 ## (2017-10-25)
 

--- a/layers/meta-resin-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -42,8 +42,8 @@ RESIN_CONFIGS[fbtft] = " \
 
 RESIN_CONFIGS_append = " pca955_gpio_expander"
 RESIN_CONFIGS[pca955_gpio_expander] = " \
-    GPIO_PCA953X=y \
-    GPIO_PCA953X_IRQ=y \
+    CONFIG_GPIO_PCA953X=y \
+    CONFIG_GPIO_PCA953X_IRQ=y \
     "
 
 KERNEL_MODULE_AUTOLOAD += "bcm2708_wdog"


### PR DESCRIPTION
Signed-off-by: Florin Sarbu <florin@resin.io>