### PR TITLE
bcm2835-bootfiles: Exclude from resinOS the firmware files with debug asssertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Exclude from resinOS the debug versions of boot firmware [Florin]
 * Fix obsolete reference to older debug-image [Florin]
 * Fix typo in enabling support for PCA955 GPIO expander [Florin]
 

--- a/layers/meta-resin-raspberrypi/recipes-bsp/bootfiles/bcm2835-bootfiles.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-bsp/bootfiles/bcm2835-bootfiles.bbappend
@@ -1,0 +1,5 @@
+# exclude from resinOS the binaries with additional debug assertions (they grow the used size in resin-boot and this potentially breaks hostapps update)
+do_deploy_append() {
+    rm ${DEPLOYDIR}/${PN}/fixup_db.dat
+    rm ${DEPLOYDIR}/${PN}/start_db.elf
+}


### PR DESCRIPTION
We do not add to resinOS the files fixup_db.dat and start_db.elf
which are esentially versions of fixup_x.dat and start_x.elf with debug assertions
enabled.
By removing them we free up about 4.8 MB from resin-boot (having less
free space in resin-boot makes it probable that hostapps update will fail when one of the
files in this boot partition grows in size in the future, such as the kernel for example; when
one file in resin-boot is bigger than the available free space, hostapps update will error out
because it tries to do an atomic update of the bootfiles).

Signed-off-by: Florin Sarbu <florin@resin.io>