### PR TITLE
rpi-config_git.bbappend: Fix obsolete reference to debug-image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Fix obsolete reference to older debug-image [Florin]
 * Fix typo in enabling support for PCA955 GPIO expander [Florin]
 
 # v2.7.4+rev1

--- a/layers/meta-resin-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-bsp/bootfiles/rpi-config_git.bbappend
@@ -6,7 +6,7 @@ do_deploy_append() {
     # Disable firmware splash by default
     echo "disable_splash=1" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     # Disable firmware warnings showing in non-debug images
-    if ! ${@bb.utils.contains('DISTRO_FEATURES','debug-image','true','false',d)}; then
+    if ! ${@bb.utils.contains('DISTRO_FEATURES','development-image','true','false',d)}; then
         echo "avoid_warnings=1" >>${DEPLOYDIR}/bcm2835-bootfiles/config.txt
     fi
     # Enable audio (loads snd_bcm2835)


### PR DESCRIPTION
The flag name has been changed from debug-image to development-image

Signed-off-by: Florin Sarbu <florin@resin.io>