### PR TITLE
bluez5_%.bbappend: Unmask brcm43438.service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Make bluetooth be enabled by default in the host OS [Florin]
 * Add the latest SD8887 Marvel Wi-Fi firmware from linux-firmware git into image [Sebastian]
 
 # v2.9.1+rev1

--- a/layers/meta-resin-raspberrypi/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -1,22 +1,4 @@
-# disable brcm43438.service unit; instead these operations should be handled from within the
-# user container as on rpi3 uart0 can be switched with uart1, rendering this service unusable
-
-pkg_postinst_${PN}_append_raspberrypi3 () {
-	if [ -n "$D" ]; then
-		OPTS="--root=$D"
-	fi
-	systemctl $OPTS mask brcm43438.service
-}
-
-# apply the same patches we apply for the rpi3. this makes bluetooth on
-# rpi0-wireless actually work.
-# The following was copied from meta-raspberrypi/ - keep it in sync.
-pkg_postinst_${PN}_append_raspberrypi () {
-	if [ -n "$D" ]; then
-		OPTS="--root=$D"
-	fi
-	systemctl $OPTS mask brcm43438.service
-}
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 # XXX raspberrypi3-64 inherits raspberrypi and raspberrypi3.
 # this is a type of uniq(SRC_URI)
@@ -25,6 +7,10 @@ do_patch_prepend() {
     unique = " ".join(list(set(src_uri.split())))
     d.setVar("SRC_URI", unique)
 }
+
+# apply the same patches we apply for the rpi3. this makes bluetooth on
+# rpi0-wireless actually work.
+# The following was copied from meta-raspberrypi/ - keep it in sync.
 
 SRC_URI_append_raspberrypi = " \
     file://BCM43430A1.hcd \

--- a/layers/meta-resin-raspberrypi/recipes-connectivity/bluez5/files/brcm43438.service
+++ b/layers/meta-resin-raspberrypi/recipes-connectivity/bluez5/files/brcm43438.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Broadcom BCM43438 bluetooth HCI
+ConditionPathIsDirectory=/proc/device-tree/soc/gpio@7e200000/bt_pins
+Before=bluetooth.service
+After=dev-serial1.device
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/hciattach -n /dev/serial1 bcm43xx 921600 noflow -
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
We unmask the brcm43438.service systemd service so that bluetooth is enabled
by default from the host OS.
If users load a dtb overlay to switch from uart0 to uart1, this would make
the brcm43438.service not work anymore since this service is hardcoded to
use ttyAMA0 and specific baudrate. In such cases, it is the user's responsability
to run hciattach with the correct parameters through the user container, based on
the uart he has switched to.

Signed-off-by: Florin Sarbu <florin@resin.io>