### PR TITLE
Unifying all devices using resin-rootA/B as root partition

### DIFF
--- a/layers/meta-resin-raspberrypi/recipes-support/hostapp-update-hooks/files/99-rpi-bootloader
+++ b/layers/meta-resin-raspberrypi/recipes-support/hostapp-update-hooks/files/99-rpi-bootloader
@@ -16,12 +16,11 @@ else
 fi
 
 new_part=$(findmnt --noheadings --canonicalize --output SOURCE $SYSROOT)
-blockdev=$(basename "$new_part")
-new_part_idx=$(cat "/sys/class/block/$blockdev/partition")
+new_part_label=$(blkid "$new_part" | awk '{print $2}')
 
-printf "[INFO] Switching RaspberryPi bootloader root partition index to %s..." "$new_part_idx..."
+printf "[INFO] Switching RaspberryPi bootloader root partition index to %s..." "$new_part_label..."
 cp /mnt/boot/cmdline.txt /mnt/boot/cmdline.txt.new
-sed -i "s#mmcblk0p.#mmcblk0p$new_part_idx#g" /mnt/boot/cmdline.txt.new
+sed -i "s/root=[^ ]* /"root=$new_part_label" /mnt/boot/cmdline.txt.new
 sync -f /mnt/boot
 mv /mnt/boot/cmdline.txt.new /mnt/boot/cmdline.txt
 sync -f /mnt/boot


### PR DESCRIPTION
Unifying boot, by using partition label resin-rootA/B instead of physical mmcblk0p2/3