### PR TITLE
Unifying boot, by using partition label resin-rootA/B instead of physical mmcblk0p2/3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Change log
 -----------
 
+* Modify linux-raspberrypi_%.bbappend: Use filesystem labels for the root cmdline kernel parameter [TheOnlyZby]
+* Modify 99-rpi-bootloader hostapp hook to switch Partition Labels instead of physical mount point [TheOnlyZby]
+
 # v2.9.7+rev1
 ## (2018-02-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Change log
 * Modify linux-raspberrypi_%.bbappend: Use filesystem labels for the root cmdline kernel parameter [TheOnlyZby]
 * Modify 99-rpi-bootloader hostapp hook to switch Partition Labels instead of physical mount point [TheOnlyZby]
 
+
 # v2.9.7+rev1
 ## (2018-02-07)
 

--- a/layers/meta-resin-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -9,8 +9,8 @@ LINUX_VERSION = "4.9.59"
 SRCREV = "e7976b2affa8c05bd299ead0ad9c36ddaf135b9d"
 
 # Set console accordingly to build type
-DEBUG_CMDLINE = "dwc_otg.lpm_enable=0 console=tty1 console=serial0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 rootwait"
-PRODUCTION_CMDLINE = "dwc_otg.lpm_enable=0 console=null root=/dev/mmcblk0p2 rootfstype=ext4 rootwait vt.global_cursor_default=0"
+DEBUG_CMDLINE = "dwc_otg.lpm_enable=0 console=tty1 console=serial0,115200 root=LABEL=resin-rootA rootfstype=ext4 rootwait"
+PRODUCTION_CMDLINE = "dwc_otg.lpm_enable=0 console=null root=LABEL=resin-rootA rootfstype=ext4 rootwait vt.global_cursor_default=0"
 CMDLINE = "${@bb.utils.contains('DISTRO_FEATURES','development-image',"${DEBUG_CMDLINE}","${PRODUCTION_CMDLINE}",d)}"
 CMDLINE_DEBUG = ""
 

--- a/layers/meta-resin-raspberrypi/recipes-support/hostapp-update-hooks/files/99-rpi-bootloader
+++ b/layers/meta-resin-raspberrypi/recipes-support/hostapp-update-hooks/files/99-rpi-bootloader
@@ -15,13 +15,11 @@ else
        SYSROOT="/mnt/sysroot/active"
 fi
 
-new_part=$(findmnt --noheadings --canonicalize --output SOURCE $SYSROOT)
-blockdev=$(basename "$new_part")
-new_part_idx=$(cat "/sys/class/block/$blockdev/partition")
+new_root_filesystem_label=$(findmnt --noheadings --canonicalize --output LABEL $SYSROOT)
 
-printf "[INFO] Switching RaspberryPi bootloader root partition index to %s..." "$new_part_idx..."
+printf "[INFO] Switching RaspberryPi bootloader root partition to %s..." "$new_root_filesystem_label..."
 cp /mnt/boot/cmdline.txt /mnt/boot/cmdline.txt.new
-sed -i "s#mmcblk0p.#mmcblk0p$new_part_idx#g" /mnt/boot/cmdline.txt.new
+sed -i "s#root=LABEL=[^ ]*#root=LABEL=$new_root_filesystem_label#g" /mnt/boot/cmdline.txt.new
 sync -f /mnt/boot
 mv /mnt/boot/cmdline.txt.new /mnt/boot/cmdline.txt
 sync -f /mnt/boot


### PR DESCRIPTION
Partition label to boot instead of physical one, in order to boot from SD Card, USB or HardDisk.
Cf Forum discussion with @agherzan
https://forums.resin.io/t/raspberry-to-run-resin-io-from-hard-disk/2413
resin-os/meta-resin#918

I hope this will help, Henry