### PR TITLE
fincm3.coffee: Remove superfluous wait instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Remove superfluous wait instruction from the fincm3.coffee file [Florin]
+
 # v2.12.7+rev1
 ## (2018-05-04)
 

--- a/fincm3.coffee
+++ b/fincm3.coffee
@@ -22,7 +22,6 @@ module.exports =
 		FIN_WRITE
 		FIN_POWEROFF
 		instructions.CONNECT_AND_BOOT
-		instructions.WAIT
 	]
 
 	gettingStartedLink:


### PR DESCRIPTION
There already is the following instruction:

"Your device should appear in your application dashboard within a few minutes. Have fun!"

Signed-off-by: Florin Sarbu <florin@resin.io>