### PR TITLE
bluez5_%.bbappend: Fix bluetooth on rpi zero wireless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Fix bluetooth on rpi zero wireless [Florin]
 * modemmanager: fix support for Huawei MS2372 modem [Sebastian]
 
 # v2.13.1+rev1

--- a/layers/meta-resin-raspberrypi/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -1,1 +1,9 @@
 SRC_URI_append_raspberrypi = " ${BCM_BT_SOURCES}"
+
+do_install_append_raspberrypi() {
+    enable_bcm_bluetooth
+}
+
+SYSTEMD_SERVICE_${PN}_append_raspberrypi = " ${BCM_BT_SERVICE}"
+
+RDEPENDS_${PN}_append_raspberrypi = " ${BCM_BT_RDEPENDS}"


### PR DESCRIPTION
Changing to sumo branch, the brcm43438.service systemd service wasn't getting installed in the
raspberry pi zero wireless rootfs.

Signed-off-by: Florin Sarbu <florin@resin.io>