### PR TITLE
networkmanager: Disable WiFi powersave mode for Balena Fin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Disable WiFi power saving mode on the Balena Fin board [Florin]
 * Fix bluetooth on rpi zero wireless [Florin]
 * modemmanager: fix support for Huawei MS2372 modem [Sebastian]
 

--- a/layers/meta-resin-raspberrypi/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -1,0 +1,10 @@
+do_install_append_fincm3() {
+    # disable wifi power saving mode on the Balena Fin board to workaround a bug where the WiFi firmware won't reconnect after entering power save mode
+    cat >> ${D}${sysconfdir}/NetworkManager/NetworkManager.conf <<EOF
+
+[connection]
+# Values are 0 (use default), 1 (ignore/don't touch), 2 (disable) or 3 (enable).
+wifi.powersave = 2
+
+EOF
+}


### PR DESCRIPTION
We do this to workaround a bug where the WiFi firmware won't reconnect after entering power save mode
(the proper fix would be to use a wifi firmware which does not have this bug but at this point we do
not have such firmware).

Signed-off-by: Florin Sarbu <florin@resin.io>