### PR TITLE
Load kernel from rootfs

### DIFF
--- a/layers/meta-resin-raspberrypi/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr/boot.cmd.in
+++ b/layers/meta-resin-raspberrypi/recipes-bsp/rpi-u-boot-scr/rpi-u-boot-scr/boot.cmd.in
@@ -4,5 +4,5 @@ fdt addr ${fdt_addr}
 fdt get value bootargs /chosen bootargs
 env set bootargs "${bootargs} ${resin_kernel_root} rootwait"
 fdt rm /chosen bootargs
-fatload ${resin_dev_type} ${resin_dev_index}:${resin_boot_part} ${resin_kernel_load_addr} @@KERNEL_IMAGETYPE@@
+ext4load ${resin_dev_type} ${resin_dev_index}:${resin_root_part} ${resin_kernel_load_addr} /boot/@@KERNEL_IMAGETYPE@@
 @@KERNEL_BOOTCMD@@ ${resin_kernel_load_addr} - ${fdt_addr}

--- a/layers/meta-resin-raspberrypi/recipes-core/images/resin-image.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-core/images/resin-image.bbappend
@@ -10,7 +10,6 @@ RESIN_IMAGE_BOOTLOADER_rpi = "bcm2835-bootfiles"
 RESIN_BOOT_PARTITION_FILES_rpi = " \
     u-boot.bin:/${SDIMG_KERNELIMAGE} \
     boot.scr:/boot.scr \
-    ${KERNEL_IMAGETYPE}${KERNEL_INITRAMFS}-${MACHINE}.bin:/${KERNEL_IMAGETYPE} \
     bcm2835-bootfiles:/ \
     "
 


### PR DESCRIPTION
When https://github.com/resin-os/meta-resin/pull/1153 is merged in meta-resin, the kernel will be available in the rootfs partition.

Load the kernel from the rootfs partition.

This PR will require the submodules to be updated to the rev that meta-resin is https://github.com/resin-os/meta-resin/pull/1153