### PR TITLE
Use the dtb overlays loaded by Pi firmware instead of u-boot built-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Use the DTB loaded by the pi firmware in u-boot [ZubairLK]
+
 # v2.14.3+rev1
 ## (2018-08-14)
 

--- a/layers/meta-resin-raspberrypi/recipes-bsp/u-boot/u-boot/rpi-Use-CONFIG_OF_BOARD-instead-of-CONFIG_EMBED.patch
+++ b/layers/meta-resin-raspberrypi/recipes-bsp/u-boot/u-boot/rpi-Use-CONFIG_OF_BOARD-instead-of-CONFIG_EMBED.patch
@@ -1,0 +1,87 @@
+From 8a4d210c5ef994891177c800c61c1c2336a3a233 Mon Sep 17 00:00:00 2001
+From: Zubair Lutfullah Kakakhel <zubair@resin.io>
+Date: Wed, 22 Aug 2018 12:45:23 +0100
+Subject: [PATCH] rpi: Use CONFIG_OF_BOARD instead of CONFIG_EMBED
+
+We have the dtb loaded by the pi firmware in resinOS.
+User CONFIG_OF_BOARD to use that dtb instead of any dtb built into
+u-boot itself which is in the default defconfigs.
+
+Signed-off-by: Zubair Lutfullah Kakakhel <zubair@resin.io>
+Upstream-Status: Inappropriate [configuration]
+---
+ configs/rpi_0_w_defconfig   | 2 +-
+ configs/rpi_2_defconfig     | 2 +-
+ configs/rpi_3_32b_defconfig | 2 +-
+ configs/rpi_3_defconfig     | 2 +-
+ configs/rpi_defconfig       | 2 +-
+ 5 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/configs/rpi_0_w_defconfig b/configs/rpi_0_w_defconfig
+index 5c24c17..9dfa22a 100644
+--- a/configs/rpi_0_w_defconfig
++++ b/configs/rpi_0_w_defconfig
+@@ -12,7 +12,7 @@ CONFIG_SYS_PROMPT="U-Boot> "
+ CONFIG_CMD_GPIO=y
+ CONFIG_CMD_MMC=y
+ CONFIG_CMD_USB=y
+-CONFIG_OF_EMBED=y
++CONFIG_OF_BOARD=y
+ CONFIG_ENV_FAT_INTERFACE="mmc"
+ CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
+ CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
+diff --git a/configs/rpi_2_defconfig b/configs/rpi_2_defconfig
+index 45b6625..e54718b 100644
+--- a/configs/rpi_2_defconfig
++++ b/configs/rpi_2_defconfig
+@@ -12,7 +12,7 @@ CONFIG_SYS_PROMPT="U-Boot> "
+ CONFIG_CMD_GPIO=y
+ CONFIG_CMD_MMC=y
+ CONFIG_CMD_USB=y
+-CONFIG_OF_EMBED=y
++CONFIG_OF_BOARD=y
+ CONFIG_ENV_FAT_INTERFACE="mmc"
+ CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
+ CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
+diff --git a/configs/rpi_3_32b_defconfig b/configs/rpi_3_32b_defconfig
+index dacf8c0..5727d96 100644
+--- a/configs/rpi_3_32b_defconfig
++++ b/configs/rpi_3_32b_defconfig
+@@ -13,7 +13,7 @@ CONFIG_SYS_PROMPT="U-Boot> "
+ CONFIG_CMD_GPIO=y
+ CONFIG_CMD_MMC=y
+ CONFIG_CMD_USB=y
+-CONFIG_OF_EMBED=y
++CONFIG_OF_BOARD=y
+ CONFIG_ENV_FAT_INTERFACE="mmc"
+ CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
+ CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
+diff --git a/configs/rpi_3_defconfig b/configs/rpi_3_defconfig
+index 4ef87dc..ab65320 100644
+--- a/configs/rpi_3_defconfig
++++ b/configs/rpi_3_defconfig
+@@ -13,7 +13,7 @@ CONFIG_SYS_PROMPT="U-Boot> "
+ CONFIG_CMD_GPIO=y
+ CONFIG_CMD_MMC=y
+ CONFIG_CMD_USB=y
+-CONFIG_OF_EMBED=y
++CONFIG_OF_BOARD=y
+ CONFIG_ENV_FAT_INTERFACE="mmc"
+ CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
+ CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
+diff --git a/configs/rpi_defconfig b/configs/rpi_defconfig
+index aa0de2f..ee91c58 100644
+--- a/configs/rpi_defconfig
++++ b/configs/rpi_defconfig
+@@ -12,7 +12,7 @@ CONFIG_SYS_PROMPT="U-Boot> "
+ CONFIG_CMD_GPIO=y
+ CONFIG_CMD_MMC=y
+ CONFIG_CMD_USB=y
+-CONFIG_OF_EMBED=y
++CONFIG_OF_BOARD=y
+ CONFIG_ENV_FAT_INTERFACE="mmc"
+ CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
+ CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
+-- 
+2.7.4
+

--- a/layers/meta-resin-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -11,4 +11,5 @@ SRC_URI_remove = " file://resin-specific-env-integration-kconfig.patch "
 
 SRC_URI += "file://rpi-Add-autoboot-configuration-in-defconfigs.patch \
             file://0001-Integrate-machine-independent-resin-environment-conf.patch \
+            file://rpi-Use-CONFIG_OF_BOARD-instead-of-CONFIG_EMBED.patch \
             "


### PR DESCRIPTION
U-boot by default embeds a dtb inside the binary.
In resinOS, we'd like u-boot to use the firmware loaded by the pi firmware.

This PR does that

Fixes https://github.com/resin-os/resin-raspberrypi/issues/228