### PR TITLE
Move udev rules from /etc to /lib

### DIFF
--- a/layers/meta-resin-raspberrypi/recipes-bsp/u-blox-modeswitch/u-blox-modeswitch.bb
+++ b/layers/meta-resin-raspberrypi/recipes-bsp/u-blox-modeswitch/u-blox-modeswitch.bb
@@ -15,8 +15,8 @@ SRC_URI = 	"file://99-u-blox_switch_to_ecm.rules \
 do_install() {
     install -d ${D}${bindir}
     install -m 0755 ${WORKDIR}/u-blox-switch.sh ${D}${bindir}
-    install -d ${D}${sysconfdir}/udev/rules.d
-    install -m 0644 ${WORKDIR}/99-u-blox_switch_to_ecm.rules ${D}${sysconfdir}/udev/rules.d
+    install -d ${D}${base_libdir}/udev/rules.d
+    install -m 0644 ${WORKDIR}/99-u-blox_switch_to_ecm.rules ${D}${base_libdir}/udev/rules.d
 
     if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
         install -d ${D}${systemd_unitdir}/system
@@ -25,7 +25,7 @@ do_install() {
 }
 
 FILES_${PN} = " \
-  /etc/udev/rules.d/99-u-blox_switch_to_ecm.rules \
+  /lib/udev/rules.d/99-u-blox_switch_to_ecm.rules \
   /lib/systemd/system/u-blox-switch@.service \
   /usr/bin/u-blox-switch.sh \
 "

--- a/layers/meta-resin-raspberrypi/recipes-core/udev/udev-rules-rpi.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-core/udev/udev-rules-rpi.bbappend
@@ -1,0 +1,5 @@
+do_install_append () {
+    # Move udev rules into /lib as /etc/udev/rules.d is bind mounted for custom rules
+    install -d ${D}${base_libdir}/udev/rules.d
+    mv ${D}/etc/udev/rules.d/*.rules ${D}${base_libdir}/udev/rules.d/
+}


### PR DESCRIPTION
The /etc/udev/rules.d directory will be used by custom udev rules when https://github.com/resin-os/meta-resin/pull/1206 is merged.

Install the rules in /lib/udev/rules.d instead of /etc