### PR TITLE
u-boot: Disable rollbacks

### DIFF
--- a/layers/meta-resin-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/layers/meta-resin-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -13,6 +13,4 @@ SRC_URI += "file://rpi-Add-autoboot-configuration-in-defconfigs.patch \
             file://0001-Integrate-machine-independent-resin-environment-conf.patch \
             file://rpi-Use-CONFIG_OF_BOARD-instead-of-CONFIG_EMBED.patch \
             file://bootcount-Add-support-to-write-bootcount-to-any-file.patch \
-            file://configs-Add-bootcount-configs-to-rpi-defconfigs.patch \
-            file://rpi.h-Add-bootlimit-and-altbootcmd-to-environment.patch \
             "


### PR DESCRIPTION
The current integration in uboot uses the ext bootcount driver which
doesn't use upgrade_available. The entire rollback support design is
currently based on this variable (upgrade_available) so if that is not
taken into consideration the board will increment bootcount with every
boot breaking the board after the first boot. Disable for now this
feature.

Changelog-entry: Disable rollbacks
Signed-off-by: Andrei Gherzan <andrei@balena.io>